### PR TITLE
chore: gitignore Claude Code local files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,7 @@ figures/
 
 .vscode/*
 .github/prompts/*
+
+# Claude Code local files (personal settings + local agent worktrees)
+.claude/settings.local.json
+.claude/worktrees/


### PR DESCRIPTION
Adds `.claude/settings.local.json` and `.claude/worktrees/` to `.gitignore` so personal/local Claude Code state stops appearing as untracked noise. Shared `.claude/` config (commands, agents) stays committable. No tracked files are affected.